### PR TITLE
drag drop textboxes to dashboard and choose the boxes background color from a palette

### DIFF
--- a/components/ColorBox.js
+++ b/components/ColorBox.js
@@ -1,0 +1,17 @@
+import styled from "styled-components";
+export default function ColorBox({ background, onChooseColor }) {
+  return (
+    <StyledColorBox
+      background={background}
+      onClick={onChooseColor}
+    ></StyledColorBox>
+  );
+}
+
+const StyledColorBox = styled.span`
+  width: 25px;
+  height: 25px;
+  background: ${({ background }) => background};
+  border: ${({ background }) =>
+    background === "transparent" ? "var(--line-secondary)" : "none"};
+`;

--- a/components/DragContainer.js
+++ b/components/DragContainer.js
@@ -35,8 +35,9 @@ const Container = styled.section`
   position: relative;
   display: flex;
   margin-bottom: 10px;
-  width: 100wv;
+  width: 100%;
   height: 12rem;
+
   &:empty:not(:focus):before {
     content: attr(data-text);
     opacity: 0.6;

--- a/components/DragContainer.js
+++ b/components/DragContainer.js
@@ -1,0 +1,46 @@
+import styled from "styled-components";
+import Draggable from "./Draggable";
+export default function DragContainer({
+  draglist,
+  ondragstart,
+  ondrop,
+  onRightClick,
+}) {
+  return (
+    <Container
+      id="DraggableContainer"
+      onDrop={ondrop}
+      onDragOver={(event) => {
+        event.preventDefault();
+      }}
+      data-text="DRAG BACK HERE!"
+    >
+      {draglist.map((item) => (
+        <Draggable
+          key={item.id}
+          id={item.id}
+          draggable={true}
+          ondragstart={ondragstart}
+          handleRightClick={(event) => onRightClick(event, item.id)}
+          backgroundColor={item.backgroundColor}
+        >
+          {item.content}
+        </Draggable>
+      ))}
+    </Container>
+  );
+}
+
+const Container = styled.section`
+  position: relative;
+  display: flex;
+  margin-bottom: 10px;
+  width: 100wv;
+  height: 12rem;
+  &:empty:not(:focus):before {
+    content: attr(data-text);
+    opacity: 0.6;
+    align-self: center;
+    margin: 0 auto;
+  }
+`;

--- a/components/Draggable.js
+++ b/components/Draggable.js
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import { useState } from "react";
+export default function Draggable({
+  id,
+  draggable,
+  ondragstart,
+  children,
+  handleRightClick,
+  backgroundColor,
+}) {
+  return (
+    <>
+      <DragBox
+        id={id}
+        draggable={draggable}
+        onDragStart={ondragstart}
+        onDrop={(event) => event.preventDefault()}
+        onContextMenu={handleRightClick}
+        color={backgroundColor}
+      >
+        {children}
+      </DragBox>
+    </>
+  );
+}
+
+const DragBox = styled.span`
+  padding: 10px;
+  margin-right: 10px;
+  width: 11rem;
+  height: 12rem;
+  box-shadow: 1px 2px 3px 4px rgba(20, 20, 20, 0.4);
+  text-overflow: clip;
+  overflow: hidden;
+  resize: horizontal;
+  background: ${({ color }) => color}
+  }
+`;

--- a/components/Dropzone.js
+++ b/components/Dropzone.js
@@ -1,0 +1,32 @@
+import styled from "styled-components";
+
+export default function Dropzone({ id, ondragover, ondrop, children }) {
+  return (
+    <DropArea
+      data-text="DROP HERE!"
+      id={id}
+      onDragOver={ondragover}
+      onDrop={ondrop}
+    >
+      {children}
+    </DropArea>
+  );
+}
+
+const DropArea = styled.section`
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+  gap: 20px;
+  width: 100wv;
+  height: 14rem;
+  border: var(--line-secondary);
+  padding: 10px;
+  margin: 10px 0;
+  &:empty:not(:focus):before {
+    content: attr(data-text);
+    opacity: 0.6;
+    align-self: center;
+    grid-column: 3;
+  }
+`;

--- a/components/Dropzone.js
+++ b/components/Dropzone.js
@@ -16,17 +16,18 @@ export default function Dropzone({ id, ondragover, ondrop, children }) {
 const DropArea = styled.section`
   position: relative;
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr 1fr;
+  grid-template-columns: repeat(4, 1fr);
+  grid-template-rows: repeat(2, 1fr);
   gap: 20px;
-  width: 100wv;
-  height: 14rem;
+  width: 100%;
+  height: 30rem;
   border: var(--line-secondary);
   padding: 10px;
   margin: 10px 0;
   &:empty:not(:focus):before {
     content: attr(data-text);
     opacity: 0.6;
-    align-self: center;
+    grid-row: 2;
     grid-column: 3;
   }
 `;

--- a/components/Layout.js
+++ b/components/Layout.js
@@ -14,7 +14,7 @@ export default function Layout({ children }) {
 
 const StyledLayout = styled.section`
   display: grid;
-  width: 100vw;
+  width: 100%;
   padding: 3rem;
   grid-template-rows: 1fr 2rem;
   gap: 10px;

--- a/components/NavigationBar.js
+++ b/components/NavigationBar.js
@@ -15,6 +15,11 @@ export default function NavigationBar({ className }) {
           Collections
         </StyledLink>
       </Link>
+      <Link href="/dashboard" passHref>
+        <StyledLink active={router.pathname === "/dashboard"}>
+          Dashboard
+        </StyledLink>
+      </Link>
       <Link href="/search" passHref>
         <StyledLink active={router.pathname === "/search"}>
           <Icon icon="ant-design:file-search-outlined" />

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -116,6 +116,7 @@ export default function Dashboard() {
       {colorPalette.display && (
         <ColorPalette
           id="ColorPalette"
+          key={Math.random().toString(36).substring(2)}
           top={colorPalette.posY}
           left={colorPalette.posX}
         >
@@ -127,7 +128,6 @@ export default function Dashboard() {
           ))}
         </ColorPalette>
       )}
-
       <DragContainer
         id="DraggableContainer"
         draglist={draggableItems}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -147,7 +147,7 @@ export default function Dashboard() {
 
       <DropzoneContainer>
         {dropzones.map((dropzone) => (
-          <DZWrapper key="wrapper">
+          <DZWrapper key={Math.random().toString(36).substring(2)}>
             <Dropzone
               key={dropzone.id}
               ondragover={(event) => {

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -31,6 +31,30 @@ const draglist = [
       "ned or moved too fast. I think it’s been good and a successful program that we’ve gotten this far this fast. Remember though that we still think there’s a need for ongoing rate increases, a",
     backgroundColor: "transparent",
   },
+  {
+    id: "3671",
+    content:
+      "ay night (8 November) expecting a Republican landslide, as of Wednesday morning we still do not know who will control the Senate or even the House, which Republicans were supposed to win easily. Democrats held on in swing districts in Virginia; they even flipped some in Ohio. And while Florida looks lost from Democrats to Republicans for the foreseeable future, Pennsylvania (where John Fetterman won the Senate race), Wisconsin and Arizona, all of which Biden won in 2020, appear to be at the very least still in play for the party. The Democra",
+    backgroundColor: "transparent",
+  },
+  {
+    id: "9808",
+    content:
+      "use (the latter, at least, will still almost certainly be Republican; midterms are meant to be bad for the party in power). And we will undoubtedly hear competing explanations as to what happened. Some will say moderates were scared off by Donald Trump’s continued dominance of the Republican Party; others, that they lost because he wasn’t on the ballot. There will b",
+    backgroundColor: "transparent",
+  },
+  {
+    id: "0983",
+    content:
+      " reject political debate on right-wing terms. I’m going to take this opportunity to do the same: however Republicans try to spin the results, whatever nonsensical claims of fraud they draw up, their electoral offer was rejected by many who were expected to eagerly vote for it. They put up bad candidates and they ran extremist campaigns. They beat themselves. If they don",
+    backgroundColor: "transparent",
+  },
+  {
+    id: "9084",
+    content:
+      "Midterm elections are meant to be bad for the party in power. Midterms are definitely meant to be bad for the party in power when inflation and gas prices are high and the president isn’t popular with voters",
+    backgroundColor: "transparent",
+  },
 ];
 
 const colorSet = [
@@ -40,7 +64,7 @@ const colorSet = [
   { id: "986", color: "#9CD0E8" },
   { id: "455", color: "#E194B8" },
 ];
-const MAX_DROP_ITEMS = 4;
+const MAX_DROP_ITEMS = 8;
 
 export default function Dashboard() {
   const [draggableItems, setDraggableItems] = useState(draglist);
@@ -51,8 +75,8 @@ export default function Dashboard() {
   const [dropzones, setDropzones] = useState([
     {
       id: Math.random().toString(36).substring(2),
+      text: "Drop here!",
     },
-    { text: "Drop here!" },
   ]);
 
   const [colorPalette, setColorPalette] = useState({});
@@ -107,21 +131,17 @@ export default function Dashboard() {
     setDropzones((dropzones) => dropzones.filter((dz) => dz.id !== id));
   }
 
-  useEffect(() => {
-    //close the color palette by clicking outside it
-    document.body.addEventListener("click", (event) => {
-      if (event.target.id !== "ColorPalette")
-        setColorPalette((pl) => {
-          return { ...pl, display: false };
-        });
-    });
-    return () => {
-      document.body.removeEventListener("click", (event) => {
-        if (event.target.id !== "ColorPalette")
-          setColorPalette((pl) => {
-            return { ...pl, display: false };
-          });
+  //close the color palette by clicking outside it
+  function closeColorPalette(event) {
+    if (event.target.id !== "ColorPalette")
+      setColorPalette((pl) => {
+        return { ...pl, display: false };
       });
+  }
+  useEffect(() => {
+    document.body.addEventListener("click", closeColorPalette);
+    return () => {
+      document.body.removeEventListener("click", closeColorPalette);
     };
   }, []);
 
@@ -168,11 +188,13 @@ export default function Dashboard() {
             ></Dropzone>
             <StyledIcons>
               <Icon icon="fluent:save-20-filled" width="25"></Icon>
-              <Icon
-                icon="eva:file-remove-fill"
-                width="25"
-                onClick={() => removeBoard(dropzone.id)}
-              ></Icon>
+              {dropzones.length > 1 && (
+                <Icon
+                  icon="eva:file-remove-fill"
+                  width="25"
+                  onClick={() => removeBoard(dropzone.id)}
+                ></Icon>
+              )}
             </StyledIcons>
           </DZWrapper>
         ))}

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -33,7 +33,13 @@ const draglist = [
   },
 ];
 
-const colorSet = ["transparent", "#E8E19C", "#A5E89C", "#9CD0E8", "#E194B8"];
+const colorSet = [
+  { id: "5454", color: "transparent" },
+  { id: "87", color: "#E8E19C" },
+  { id: "987", color: "#A5E89C" },
+  { id: "986", color: "#9CD0E8" },
+  { id: "455", color: "#E194B8" },
+];
 const MAX_DROP_ITEMS = 4;
 
 export default function Dashboard() {
@@ -121,9 +127,9 @@ export default function Dashboard() {
         >
           {colorSet.map((color) => (
             <ColorBox
-              key={Math.random().toString(36).substring(2)}
-              background={color}
-              onChooseColor={() => chooseColor(color)}
+              key={color.id}
+              background={color.color}
+              onChooseColor={() => chooseColor(color.color)}
             />
           ))}
         </ColorPalette>
@@ -141,7 +147,7 @@ export default function Dashboard() {
 
       <DropzoneContainer>
         {dropzones.map((dropzone) => (
-          <DZWrapper>
+          <DZWrapper key="wrapper">
             <Dropzone
               key={dropzone.id}
               ondragover={(event) => {
@@ -153,7 +159,7 @@ export default function Dashboard() {
               }}
             ></Dropzone>
             <StyledIcons>
-              <Icon icon="fluent:save-20-filled" width="25"></Icon>
+              {/*  <Icon icon="fluent:save-20-filled" width="25"></Icon> */}
               <Icon
                 icon="eva:file-remove-fill"
                 width="25"

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -115,6 +115,14 @@ export default function Dashboard() {
           return { ...pl, display: false };
         });
     });
+    return () => {
+      document.body.removeEventListener("click", (event) => {
+        if (event.target.id !== "ColorPalette")
+          setColorPalette((pl) => {
+            return { ...pl, display: false };
+          });
+      });
+    };
   }, []);
 
   return (
@@ -147,7 +155,7 @@ export default function Dashboard() {
 
       <DropzoneContainer>
         {dropzones.map((dropzone) => (
-          <DZWrapper key={Math.random().toString(36).substring(2)}>
+          <DZWrapper key={dropzone.id}>
             <Dropzone
               key={dropzone.id}
               ondragover={(event) => {
@@ -159,7 +167,7 @@ export default function Dashboard() {
               }}
             ></Dropzone>
             <StyledIcons>
-              {/*  <Icon icon="fluent:save-20-filled" width="25"></Icon> */}
+              <Icon icon="fluent:save-20-filled" width="25"></Icon>
               <Icon
                 icon="eva:file-remove-fill"
                 width="25"

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -1,0 +1,212 @@
+import styled from "styled-components";
+import Dropzone from "../components/Dropzone";
+import DragContainer from "../components/DragContainer";
+import { useEffect, useState } from "react";
+import { Icon } from "@iconify/react";
+import Button from "../components/Button";
+import ColorBox from "../components/ColorBox";
+
+const draglist = [
+  {
+    id: "5343",
+    content:
+      "a quick 1% on the statement, assuming a newfound focus on “cumulative tightening” and “lags” signaled a shift in the committee’s thinking. Inklings of such a turn had already been offered by Fed officials, including Bullard, Daly, Evans and Kashkari. Markets could take comfort that the Fed was in sync with other central banks, with recent market instability forcin",
+    backgroundColor: "transparent",
+  },
+  {
+    id: "7565",
+    content:
+      "solve Paul Volcker had demonstrated some 40 years earlier. I respect and admire Powell. His Fed has made historic mistakes, but he’s determined to try to make amends. The Chair is doin",
+    backgroundColor: "transparent",
+  },
+  {
+    id: "5867",
+    content:
+      " want people to understand our commitment to getting this done. And to not making the mistake of not doing enough - or the mistake of withdrawing our strong policy and doing that",
+    backgroundColor: "transparent",
+  },
+  {
+    id: "1345",
+    content:
+      "ned or moved too fast. I think it’s been good and a successful program that we’ve gotten this far this fast. Remember though that we still think there’s a need for ongoing rate increases, a",
+    backgroundColor: "transparent",
+  },
+];
+
+const colorSet = ["transparent", "#E8E19C", "#A5E89C", "#9CD0E8", "#E194B8"];
+const MAX_DROP_ITEMS = 4;
+
+export default function Dashboard() {
+  const [draggableItems, setDraggableItems] = useState(draglist);
+  const [remainDragItemCount, setRemainDragItemCount] = useState(
+    draglist.length
+  );
+
+  const [dropzones, setDropzones] = useState([
+    {
+      id: Math.random().toString(36).substring(2),
+    },
+    { text: "Drop here!" },
+  ]);
+
+  const [colorPalette, setColorPalette] = useState({});
+  const [currentDraggable, setCurrentDraggable] = useState({
+    id: "",
+  });
+
+  function openColorPalette(event, id) {
+    event.preventDefault();
+    setCurrentDraggable({ id: id });
+
+    //popup the color pallete at right mouse click
+    setColorPalette({
+      display: true,
+      posX: event.pageX + "px",
+      posY: event.pageY + "px",
+    });
+  }
+
+  //set color background for the clicked draggable item
+  function chooseColor(color) {
+    setDraggableItems((prevlist) =>
+      prevlist.map((item) =>
+        item.id === currentDraggable.id
+          ? { ...item, backgroundColor: color }
+          : item
+      )
+    );
+    setColorPalette((pl) => {
+      return { ...pl, display: false };
+    });
+  }
+
+  function drag(event) {
+    event.dataTransfer.setData("text", event.target.id);
+  }
+  function drop(event) {
+    event.preventDefault();
+    const dataID = event.dataTransfer.getData("text");
+
+    //only allow drop for an amount equal to MAX_DROP_ITEMS items
+    if (
+      event.target.id === "DraggableContainer" ||
+      event.target.children.length <= MAX_DROP_ITEMS
+    )
+      event.currentTarget.appendChild(
+        document.querySelector(`#${CSS.escape(dataID)}`)
+      );
+  }
+
+  function removeBoard(id) {
+    setDropzones((dropzones) => dropzones.filter((dz) => dz.id !== id));
+  }
+
+  useEffect(() => {
+    //close the color palette by clicking outside it
+    document.body.addEventListener("click", (event) => {
+      if (event.target.id !== "ColorPalette")
+        setColorPalette((pl) => {
+          return { ...pl, display: false };
+        });
+    });
+  }, []);
+
+  return (
+    <>
+      {colorPalette.display && (
+        <ColorPalette
+          id="ColorPalette"
+          top={colorPalette.posY}
+          left={colorPalette.posX}
+        >
+          {colorSet.map((color) => (
+            <ColorBox
+              background={color}
+              onChooseColor={() => chooseColor(color)}
+            />
+          ))}
+        </ColorPalette>
+      )}
+
+      <DragContainer
+        id="DraggableContainer"
+        draglist={draggableItems}
+        ondragstart={drag}
+        ondrop={(event) => {
+          drop(event);
+          setRemainDragItemCount((prevCount) => prevCount + 1);
+        }}
+        onRightClick={(event, id) => openColorPalette(event, id)}
+      ></DragContainer>
+
+      <DropzoneContainer>
+        {dropzones.map((dropzone) => (
+          <DZWrapper>
+            <Dropzone
+              key={dropzone.id}
+              ondragover={(event) => {
+                event.preventDefault();
+              }}
+              ondrop={(event) => {
+                drop(event);
+                setRemainDragItemCount((prevCount) => prevCount - 1);
+              }}
+            ></Dropzone>
+            <StyledIcons>
+              <Icon icon="fluent:save-20-filled" width="25"></Icon>
+              <Icon
+                icon="eva:file-remove-fill"
+                width="25"
+                onClick={() => removeBoard(dropzone.id)}
+              ></Icon>
+            </StyledIcons>
+          </DZWrapper>
+        ))}
+        <StyledButton
+          onClick={() => {
+            setDropzones((prevDZ) => [
+              { id: Math.random().toString(36).substring(2) },
+              ...prevDZ,
+            ]);
+          }}
+        >
+          Add board
+        </StyledButton>
+      </DropzoneContainer>
+    </>
+  );
+}
+
+const DZWrapper = styled.div`
+  position: relative;
+`;
+
+const StyledButton = styled(Button)`
+  background-color: "transparent"
+  padding: 15px;
+  margin: 10px 0;
+  width:100px;
+`;
+
+const DropzoneContainer = styled.div`
+  padding: 10px 0;
+`;
+
+const StyledIcons = styled.span`
+  display: flex;
+  position: absolute;
+  top: 0;
+  right: 0;
+`;
+
+const ColorPalette = styled.span`
+  position: absolute;
+  top: ${({ top }) => top};
+  left: ${({ left }) => left};
+  background: #d3d3d3;
+  display: flex;
+  gap: 10px;
+  padding: 10px;
+  border: var(--line-secondary);
+  z-index: 2000;
+`;

--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -116,12 +116,12 @@ export default function Dashboard() {
       {colorPalette.display && (
         <ColorPalette
           id="ColorPalette"
-          key={Math.random().toString(36).substring(2)}
           top={colorPalette.posY}
           left={colorPalette.posX}
         >
           {colorSet.map((color) => (
             <ColorBox
+              key={Math.random().toString(36).substring(2)}
               background={color}
               onChooseColor={() => chooseColor(color)}
             />


### PR DESCRIPTION
The dashboard page contains:
- [ ] some dummy textboxes
- [ ] one or several boards
- [ ] a color palette popped up by right clicking on any textbox
- [ ] choice of colors from the palette for the textbox
- [ ] drag and drop textboxes in the boards
- [ ] add and delete boards